### PR TITLE
bundle all dependencies

### DIFF
--- a/denops/bufpreview/lib/filetype/markdown/client/markdown.html
+++ b/denops/bufpreview/lib/filetype/markdown/client/markdown.html
@@ -14,13 +14,13 @@
     <title>Loading...</title>
 
     <script type='module'>
-      import MarkdownIt from "https://esm.sh/markdown-it"
-      import HighlightJs from "https://esm.sh/highlight.js"
-      import KaTeX from "https://esm.sh/katex"
-      import TexMath from "http://esm.sh/markdown-it-texmath"
-      import TaskList from "http://esm.sh/markdown-it-task-lists"
-      import * as IncrementalDOM from "http://esm.sh/incremental-dom"
-      import MarkdownItIncrementalDOM from "http://esm.sh/markdown-it-incremental-dom"
+      import MarkdownIt from "https://esm.sh/markdown-it?bundle"
+      import HighlightJs from "https://esm.sh/highlight.js?bundle"
+      import KaTeX from "https://esm.sh/katex?bundle"
+      import TexMath from "http://esm.sh/markdown-it-texmath?bundle"
+      import TaskList from "http://esm.sh/markdown-it-task-lists?bundle"
+      import * as IncrementalDOM from "http://esm.sh/incremental-dom?bundle"
+      import MarkdownItIncrementalDOM from "http://esm.sh/markdown-it-incremental-dom?bundle"
 
       const md = new MarkdownIt({
         html: true,


### PR DESCRIPTION
Highlight.js loads all syntax files at the beginning. The affects the performance.
This pull request changes the markdown.html to load es modules by bundle mode of esm.sh.

Please check it! Thanks.